### PR TITLE
Io2021 c 72 request authentication

### DIFF
--- a/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
+++ b/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
@@ -120,6 +120,6 @@ public class LeaveController implements SecuredRestController {
     @Operation(summary = "Deleting leave with leaveID")
     public ResponseEntity<Void> deleteLeave(@PathVariable Long id) {
         
-        return userService.deleteUser(id);
+        return leaveService.deleteLeave(id);
     }
 }

--- a/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
+++ b/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -39,8 +40,9 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "404", description = "User not found", content = @Content()),
                 @ApiResponse(responseCode = "400", description = "Leave could not be saved", content = @Content()),
                })
-    public ResponseEntity<LeaveDTO> insertLeave(@PathVariable Long userId, @RequestBody LeaveDTO leaveDTO) {
-        Optional<User> userOpt = userService.getById(userId);
+    public ResponseEntity<LeaveDTO> insertLeave(@PathVariable Long userId, @RequestBody LeaveDTO leaveDTO
+            ,@AuthenticationPrincipal User userAuth) {
+        Optional<User> userOpt = userService.getById(userId,userAuth);
         if(userOpt.isPresent()){
             User user = userOpt.get();
             Leave leave = converters.DTOToLeave(leaveDTO);
@@ -74,8 +76,9 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of user's leaves' DTOs"),
                 @ApiResponse(responseCode = "404", description = "User not found", content = @Content())
                })
-    public ResponseEntity<List<LeaveDTO>> getLeavesByUserId(@PathVariable Long userId) {
-        Optional<User> userOpt = userService.getById(userId);
+    public ResponseEntity<List<LeaveDTO>> getLeavesByUserId(@PathVariable Long userId
+            ,@AuthenticationPrincipal User userAuth) {
+        Optional<User> userOpt = userService.getById(userId,userAuth);
         return userOpt
                 .map(user -> ResponseEntity.ok(
                         user

--- a/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
+++ b/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
@@ -43,15 +43,14 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "400", description = "Leave could not be saved", content = @Content()),
                })
     public ResponseEntity<LeaveDTO> insertLeave(@PathVariable Long userId, @RequestBody LeaveDTO leaveDTO
-            ,Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        Optional<User> userOpt = userService.getById(userId,userAuth);
+            ) {
+        
+        Optional<User> userOpt = userService.getById(userId);
         if(userOpt.isPresent()){
             User user = userOpt.get();
             Leave leave = converters.DTOToLeave(leaveDTO);
             leave.setUser(user);
-            Optional<Leave> insertedLeaveOpt = leaveService.saveLeave(leave,userAuth,true);
+            Optional<Leave> insertedLeaveOpt = leaveService.saveLeave(leave,true);
             return insertedLeaveOpt
                     .map(insertedLeave -> ResponseEntity.ok(converters.leaveToDTO(insertedLeave)))
                     .orElseGet(() -> ResponseEntity.badRequest().build());
@@ -67,11 +66,10 @@ public class LeaveController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of all leaves")
                })
-    public ResponseEntity<List<LeaveDTO>> getAllLeaves(Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
+    public ResponseEntity<List<LeaveDTO>> getAllLeaves() {
+        
         return ResponseEntity.ok(
-                leaveService.getAllLeaves(userAuth).stream().map(converters::leaveToDTO)
+                leaveService.getAllLeaves().stream().map(converters::leaveToDTO)
                         .collect(Collectors.toList())
         );
     }
@@ -83,10 +81,9 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "404", description = "User not found", content = @Content())
                })
     public ResponseEntity<List<LeaveDTO>> getLeavesByUserId(@PathVariable Long userId
-            ,Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        Optional<User> userOpt = userService.getById(userId,userAuth);
+            ) {
+        
+        Optional<User> userOpt = userService.getById(userId);
         return userOpt
                 .map(user -> ResponseEntity.ok(
                         user
@@ -105,14 +102,13 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "404", description = "Leave not found"),
                 @ApiResponse(responseCode = "400", description = "Leave could not be saved")
                })
-    public ResponseEntity<Void> updateLeave(@RequestBody LeaveDTO leaveDTO,Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        Optional<Leave> leaveOpt = leaveService.getById(leaveDTO.getId(),userAuth);
+    public ResponseEntity<Void> updateLeave(@RequestBody LeaveDTO leaveDTO) {
+        
+        Optional<Leave> leaveOpt = leaveService.getById(leaveDTO.getId());
         if(leaveOpt.isPresent()){
             Leave leave = leaveOpt.get();
             converters.updateLeaveWithDTO(leaveDTO, leave);
-            return leaveService.saveLeave(leave,userAuth,false).isPresent() ?
+            return leaveService.saveLeave(leave,false).isPresent() ?
                     ResponseEntity.ok().build() : ResponseEntity.badRequest().build();
         }
         else
@@ -122,9 +118,8 @@ public class LeaveController implements SecuredRestController {
     //// DELETE
     @DeleteMapping(value = "/leave/{id}")
     @Operation(summary = "Deleting leave with leaveID")
-    public ResponseEntity<Void> deleteLeave(@PathVariable Long id,Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return userService.deleteUser(id,userAuth);
+    public ResponseEntity<Void> deleteLeave(@PathVariable Long id) {
+        
+        return userService.deleteUser(id);
     }
 }

--- a/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
+++ b/spring-app/src/main/java/com/agh/hr/controllers/LeaveController.java
@@ -12,9 +12,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -41,7 +43,9 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "400", description = "Leave could not be saved", content = @Content()),
                })
     public ResponseEntity<LeaveDTO> insertLeave(@PathVariable Long userId, @RequestBody LeaveDTO leaveDTO
-            ,@AuthenticationPrincipal User userAuth) {
+            ,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         Optional<User> userOpt = userService.getById(userId,userAuth);
         if(userOpt.isPresent()){
             User user = userOpt.get();
@@ -63,7 +67,9 @@ public class LeaveController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of all leaves")
                })
-    public ResponseEntity<List<LeaveDTO>> getAllLeaves(@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<List<LeaveDTO>> getAllLeaves(Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(
                 leaveService.getAllLeaves(userAuth).stream().map(converters::leaveToDTO)
                         .collect(Collectors.toList())
@@ -77,7 +83,9 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "404", description = "User not found", content = @Content())
                })
     public ResponseEntity<List<LeaveDTO>> getLeavesByUserId(@PathVariable Long userId
-            ,@AuthenticationPrincipal User userAuth) {
+            ,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         Optional<User> userOpt = userService.getById(userId,userAuth);
         return userOpt
                 .map(user -> ResponseEntity.ok(
@@ -97,7 +105,9 @@ public class LeaveController implements SecuredRestController {
                 @ApiResponse(responseCode = "404", description = "Leave not found"),
                 @ApiResponse(responseCode = "400", description = "Leave could not be saved")
                })
-    public ResponseEntity<Void> updateLeave(@RequestBody LeaveDTO leaveDTO,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<Void> updateLeave(@RequestBody LeaveDTO leaveDTO,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         Optional<Leave> leaveOpt = leaveService.getById(leaveDTO.getId(),userAuth);
         if(leaveOpt.isPresent()){
             Leave leave = leaveOpt.get();
@@ -112,7 +122,9 @@ public class LeaveController implements SecuredRestController {
     //// DELETE
     @DeleteMapping(value = "/leave/{id}")
     @Operation(summary = "Deleting leave with leaveID")
-    public ResponseEntity<Void> deleteLeave(@PathVariable Long id,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<Void> deleteLeave(@PathVariable Long id,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return userService.deleteUser(id,userAuth);
     }
 }

--- a/spring-app/src/main/java/com/agh/hr/controllers/PersonalDataController.java
+++ b/spring-app/src/main/java/com/agh/hr/controllers/PersonalDataController.java
@@ -12,9 +12,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -39,7 +41,9 @@ public class PersonalDataController implements SecuredRestController {
                     @ApiResponse(responseCode = "200", description = "Personal data DTO")
             })
     public ResponseEntity<PersonalDataDTO> getPersonalDataById(@PathVariable Long id,
-                                                               @AuthenticationPrincipal User userAuth) {
+                                                               Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         Optional<PersonalData> personalDataOpt =dataService.getById(id,userAuth);
         return personalDataOpt.map(data->ResponseEntity.ok(converters.personalDataToDTO(data)))
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.FORBIDDEN).build());
@@ -50,7 +54,9 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of Personal data records' DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getAllPersonalData(@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<List<PersonalDataDTO>> getAllPersonalData(Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getAllPersonalData(userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -58,7 +64,9 @@ public class PersonalDataController implements SecuredRestController {
 
     @RequestMapping(value = "/data/{PersonalDataId}", method = RequestMethod.DELETE)
     @Operation(summary = "Deleting personal data with personalDataId")
-    public ResponseEntity<Void> deletePersonalData(@PathVariable Long PersonalDataId,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<Void> deletePersonalData(@PathVariable Long PersonalDataId, Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return dataService.deletePersonalData(PersonalDataId,userAuth);
     }
 
@@ -69,7 +77,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "400", description = "Personal could not be updated")
                })
     public  ResponseEntity<Void> updatePersonalData(@RequestBody PersonalDataDTO dataDTO,
-                                                    @AuthenticationPrincipal User userAuth) {
+                                                    Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         Optional<PersonalData> personalDataOpt = dataService.getById(dataDTO.getId(),userAuth);
         if(personalDataOpt.isPresent()){
             PersonalData data = personalDataOpt.get();
@@ -87,7 +97,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByFirstname(@PathVariable String name,
-                                                                            @AuthenticationPrincipal User userAuth) {
+                                                                            Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByFirstname(name,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -99,7 +111,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByLastname(@PathVariable String name,
-                                                                           @AuthenticationPrincipal User userAuth) {
+                                                                           Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByLastname(name,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -112,7 +126,9 @@ public class PersonalDataController implements SecuredRestController {
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByFullName(@PathVariable String firstname,
                                                                            @PathVariable String lastname,
-                                                                           @AuthenticationPrincipal User userAuth) {
+                                                                           Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByFullName(firstname,lastname,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -124,7 +140,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByAddress(@PathVariable String address,
-                                                                          @AuthenticationPrincipal User userAuth) {
+                                                                          Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByAddress(address,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -136,7 +154,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByEmail(@PathVariable String email,
-                                                                        @AuthenticationPrincipal User userAuth) {
+                                                                        Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByEmail(email,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -148,7 +168,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByPhone(@PathVariable String phone,
-                                                                        @AuthenticationPrincipal User userAuth) {
+                                                                        Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByPhone(phone,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -160,7 +182,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByBirthdateEquals(@PathVariable LocalDate date,
-                                                                                  @AuthenticationPrincipal User userAuth) {
+                                                                                  Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByBirthdateEquals(date,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
@@ -173,7 +197,9 @@ public class PersonalDataController implements SecuredRestController {
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByBirthdateBetween(@PathVariable LocalDate before,
                                                                                    @PathVariable LocalDate after,
-                                                                                   @AuthenticationPrincipal User userAuth) {
+                                                                                   Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(dataService.getByBirthdateBetween(before,after,userAuth).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));

--- a/spring-app/src/main/java/com/agh/hr/controllers/PersonalDataController.java
+++ b/spring-app/src/main/java/com/agh/hr/controllers/PersonalDataController.java
@@ -40,11 +40,9 @@ public class PersonalDataController implements SecuredRestController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "Personal data DTO")
             })
-    public ResponseEntity<PersonalDataDTO> getPersonalDataById(@PathVariable Long id,
-                                                               Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        Optional<PersonalData> personalDataOpt =dataService.getById(id,userAuth);
+    public ResponseEntity<PersonalDataDTO> getPersonalDataById(@PathVariable Long id) {
+        
+        Optional<PersonalData> personalDataOpt =dataService.getById(id);
         return personalDataOpt.map(data->ResponseEntity.ok(converters.personalDataToDTO(data)))
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.FORBIDDEN).build());
     }
@@ -54,20 +52,18 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of Personal data records' DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getAllPersonalData(Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getAllPersonalData(userAuth).stream()
+    public ResponseEntity<List<PersonalDataDTO>> getAllPersonalData() {
+        
+        return ResponseEntity.ok(dataService.getAllPersonalData().stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
 
     @RequestMapping(value = "/data/{PersonalDataId}", method = RequestMethod.DELETE)
     @Operation(summary = "Deleting personal data with personalDataId")
-    public ResponseEntity<Void> deletePersonalData(@PathVariable Long PersonalDataId, Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return dataService.deletePersonalData(PersonalDataId,userAuth);
+    public ResponseEntity<Void> deletePersonalData(@PathVariable Long PersonalDataId) {
+        
+        return dataService.deletePersonalData(PersonalDataId);
     }
 
     @RequestMapping(value = "/data", method = RequestMethod.PUT)
@@ -76,15 +72,13 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "Personal data updated successfully"),
                 @ApiResponse(responseCode = "400", description = "Personal could not be updated")
                })
-    public  ResponseEntity<Void> updatePersonalData(@RequestBody PersonalDataDTO dataDTO,
-                                                    Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        Optional<PersonalData> personalDataOpt = dataService.getById(dataDTO.getId(),userAuth);
+    public  ResponseEntity<Void> updatePersonalData(@RequestBody PersonalDataDTO dataDTO) {
+        
+        Optional<PersonalData> personalDataOpt = dataService.getById(dataDTO.getId());
         if(personalDataOpt.isPresent()){
             PersonalData data = personalDataOpt.get();
             converters.updatePersonalDataWithDTO(dataDTO, data);
-            return dataService.savePersonalData(data,userAuth).isPresent() ?
+            return dataService.savePersonalData(data,false).isPresent() ?
                     ResponseEntity.ok().build() : ResponseEntity.badRequest().build();
         }
         else
@@ -96,11 +90,9 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByFirstname(@PathVariable String name,
-                                                                            Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByFirstname(name,userAuth).stream()
+    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByFirstname(@PathVariable String name) {
+        
+        return ResponseEntity.ok(dataService.getByFirstname(name).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
@@ -110,11 +102,9 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByLastname(@PathVariable String name,
-                                                                           Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByLastname(name,userAuth).stream()
+    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByLastname(@PathVariable String name) {
+        
+        return ResponseEntity.ok(dataService.getByLastname(name).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
@@ -125,11 +115,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByFullName(@PathVariable String firstname,
-                                                                           @PathVariable String lastname,
-                                                                           Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByFullName(firstname,lastname,userAuth).stream()
+                                                                           @PathVariable String lastname) {
+        
+        return ResponseEntity.ok(dataService.getByFullName(firstname,lastname).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
@@ -139,11 +127,9 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByAddress(@PathVariable String address,
-                                                                          Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByAddress(address,userAuth).stream()
+    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByAddress(@PathVariable String address) {
+        
+        return ResponseEntity.ok(dataService.getByAddress(address).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
@@ -153,11 +139,9 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByEmail(@PathVariable String email,
-                                                                        Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByEmail(email,userAuth).stream()
+    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByEmail(@PathVariable String email) {
+        
+        return ResponseEntity.ok(dataService.getByEmail(email).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
@@ -167,11 +151,9 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByPhone(@PathVariable String phone,
-                                                                        Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByPhone(phone,userAuth).stream()
+    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByPhone(@PathVariable String phone) {
+        
+        return ResponseEntity.ok(dataService.getByPhone(phone).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
@@ -181,11 +163,9 @@ public class PersonalDataController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
-    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByBirthdateEquals(@PathVariable LocalDate date,
-                                                                                  Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByBirthdateEquals(date,userAuth).stream()
+    public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByBirthdateEquals(@PathVariable LocalDate date) {
+        
+        return ResponseEntity.ok(dataService.getByBirthdateEquals(date).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }
@@ -196,11 +176,9 @@ public class PersonalDataController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of personal data DTOs")
                })
     public ResponseEntity<List<PersonalDataDTO>> getPersonalDataByBirthdateBetween(@PathVariable LocalDate before,
-                                                                                   @PathVariable LocalDate after,
-                                                                                   Principal principal) {
-        Authentication authentication = (Authentication) principal;
-        User userAuth = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(dataService.getByBirthdateBetween(before,after,userAuth).stream()
+                                                                                   @PathVariable LocalDate after) {
+        
+        return ResponseEntity.ok(dataService.getByBirthdateBetween(before,after).stream()
                 .map(converters::personalDataToDTO)
                 .collect(Collectors.toList()));
     }

--- a/spring-app/src/main/java/com/agh/hr/controllers/UserController.java
+++ b/spring-app/src/main/java/com/agh/hr/controllers/UserController.java
@@ -15,10 +15,12 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -41,7 +43,9 @@ public class UserController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "Created user's DTO"),
                 @ApiResponse(responseCode = "400", description = "User could not be created", content = @Content())
                })
-    public ResponseEntity<UserDTO> insertUser(@RequestBody UserDTO userDTO,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<UserDTO> insertUser(@RequestBody UserDTO userDTO,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         User user = converters.DTOToUser(userDTO);
         Optional<User> insertedUserOpt = userService.saveUser(user,userAuth,true);
         return insertedUserOpt
@@ -55,7 +59,9 @@ public class UserController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of all users' DTOs")
                })
-    public ResponseEntity<List<UserDTO>> getAllUsers(@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<List<UserDTO>> getAllUsers(Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(
                 userService.getAllUsers(userAuth).stream().map(converters::userToDTO)
                         .collect(Collectors.toList())
@@ -68,7 +74,9 @@ public class UserController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "The user's DTO"),
                 @ApiResponse(responseCode = "404", description = "User not found", content = @Content())
                })
-    public ResponseEntity<UserDTO> getUserById(@PathVariable Long id,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<UserDTO> getUserById(@PathVariable Long id,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         Optional<User> userOpt = userService.getById(id,userAuth);
         return userOpt
                 .map(user -> ResponseEntity.ok(converters.userToDTO(user)))
@@ -80,7 +88,9 @@ public class UserController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of matched users' DTOs")
                })
-    public ResponseEntity<List<UserDTO>> getUserByFirstname(@PathVariable String name,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<List<UserDTO>> getUserByFirstname(@PathVariable String name,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(userService.getByFirstname(name,userAuth).stream()
                 .map(converters::userToDTO)
                 .collect(Collectors.toList()));
@@ -91,7 +101,9 @@ public class UserController implements SecuredRestController {
                responses = {
                 @ApiResponse(responseCode = "200", description = "List of matched users' DTOs")
                })
-    public ResponseEntity<List<UserDTO>> getUserByLastname(@PathVariable String name,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<List<UserDTO>> getUserByLastname(@PathVariable String name, Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(userService.getByLastname(name,userAuth).stream()
                 .map(converters::userToDTO)
                 .collect(Collectors.toList()));
@@ -103,7 +115,9 @@ public class UserController implements SecuredRestController {
                 @ApiResponse(responseCode = "200", description = "List of matched users' DTOs")
                })
     public ResponseEntity<List<UserDTO>> getUserByFullName(@PathVariable String firstname,@PathVariable String lastname,
-                                                           @AuthenticationPrincipal User userAuth) {
+                                                           Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return ResponseEntity.ok(userService.getByFullName(firstname,lastname,userAuth).stream()
                 .map(converters::userToDTO)
                 .collect(Collectors.toList()));
@@ -117,7 +131,9 @@ public class UserController implements SecuredRestController {
                 @ApiResponse(responseCode = "404", description = "User not found"),
                 @ApiResponse(responseCode = "400", description = "User could not be updated")
                })
-    public ResponseEntity<Void> updateUser(@RequestBody UserDTO userDTO,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<Void> updateUser(@RequestBody UserDTO userDTO,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         Optional<User> userOpt = userService.getById(userDTO.getId(),userAuth);
         if(userOpt.isPresent()) {
             User user = userOpt.get();
@@ -133,7 +149,9 @@ public class UserController implements SecuredRestController {
     //// DELETE
     @DeleteMapping(value = "/user/{id}")
     @Operation(summary = "Deleting user with userID")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id,@AuthenticationPrincipal User userAuth) {
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id,Principal principal) {
+        Authentication authentication = (Authentication) principal;
+        User userAuth = (User) authentication.getPrincipal();
         return userService.deleteUser(id,userAuth);
     }
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
@@ -19,7 +19,6 @@ public class Converters {
     public User DTOToUser(UserDTO userDTO) {
         User user = modelMapper.map(userDTO, User.class);
         PersonalData personalData=DTOToPersonalData(userDTO.personalData);
-        personalData.setUser(user);
         user.setPersonalData(personalData);
         return user;
     }

--- a/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
@@ -41,9 +41,7 @@ public class Converters {
     }
 
     public PersonalDataDTO personalDataToDTO(PersonalData personalData) {
-        PersonalDataDTO dataDTO= modelMapper.map(personalData, PersonalDataDTO.class);
-        dataDTO.setUser(userToDTO(personalData.getUser()));
-        return dataDTO;
+        return modelMapper.map(personalData, PersonalDataDTO.class);
     }
 
     //// LEAVE

--- a/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
@@ -41,7 +41,9 @@ public class Converters {
     }
 
     public PersonalDataDTO personalDataToDTO(PersonalData personalData) {
-        return modelMapper.map(personalData, PersonalDataDTO.class);
+        PersonalDataDTO dataDTO= modelMapper.map(personalData, PersonalDataDTO.class);
+        dataDTO.setUser(userToDTO(personalData.getUser()));
+        return dataDTO;
     }
 
     //// LEAVE

--- a/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/dto/Converters.java
@@ -18,7 +18,9 @@ public class Converters {
     //// USER
     public User DTOToUser(UserDTO userDTO) {
         User user = modelMapper.map(userDTO, User.class);
-        user.setPersonalData(DTOToPersonalData(userDTO.personalData));
+        PersonalData personalData=DTOToPersonalData(userDTO.personalData);
+        personalData.setUser(user);
+        user.setPersonalData(personalData);
         return user;
     }
 

--- a/spring-app/src/main/java/com/agh/hr/persistence/dto/PersonalDataDTO.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/dto/PersonalDataDTO.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 public class PersonalDataDTO {
 
     private Long id;
+    private UserDTO user;
     private String firstname;
     private String lastname;
     private String email;

--- a/spring-app/src/main/java/com/agh/hr/persistence/dto/PersonalDataDTO.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/dto/PersonalDataDTO.java
@@ -11,7 +11,6 @@ import java.time.LocalDate;
 public class PersonalDataDTO {
 
     private Long id;
-    private UserDTO user;
     private String firstname;
     private String lastname;
     private String email;

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/Permission.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/Permission.java
@@ -31,6 +31,10 @@ public class Permission {
         return id;
     }
     public boolean addToRead(Long toAdd){ return read.add(toAdd);}
-    public boolean addToWrite(Long toAdd){return write.add(toAdd);}
+    public boolean addToWrite(Long toAdd){
+        if(!write.contains(toAdd))
+            read.add(toAdd);
+        return write.add(toAdd);
+    }
     public boolean getAdd(){return add;}
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/Permission.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/Permission.java
@@ -17,6 +17,9 @@ public class Permission {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @OneToOne(mappedBy = "permissions")
+    private User user;
+
     @ElementCollection
     @Builder.Default
     private List<Long> write=new ArrayList<>();

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/Permission.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/Permission.java
@@ -3,6 +3,7 @@ package com.agh.hr.persistence.model;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -17,14 +18,19 @@ public class Permission {
     private Long id;
 
     @ElementCollection
-    private List<Long> write;
+    @Builder.Default
+    private List<Long> write=new ArrayList<>();
 
     @ElementCollection
-    private List<Long> read;
+    @Builder.Default
+    private List<Long> read=new ArrayList<>();
 
     private boolean add;
 
     public Long getId() {
         return id;
     }
+    public boolean addToRead(Long toAdd){ return read.add(toAdd);}
+    public boolean addToWrite(Long toAdd){return write.add(toAdd);}
+    public boolean getAdd(){return add;}
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/PersonalData.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/PersonalData.java
@@ -14,6 +14,10 @@ public class PersonalData {
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    @ManyToOne
+    @JoinColumn
+    private User user;
+
     private String firstname;
 
     private String lastname;

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/PersonalData.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/PersonalData.java
@@ -14,7 +14,7 @@ public class PersonalData {
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn
     private User user;
 

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
@@ -33,7 +33,7 @@ public class User implements UserDetails {
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private PersonalData personalData;
 
-    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(cascade = CascadeType.ALL)
     private Permission permissions;
 
     private String position;
@@ -41,16 +41,16 @@ public class User implements UserDetails {
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private List<Leave> leaves;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL)
     private List<Contract> contracts;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL)
     private List<Bonus> bonuses;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL)
     private List<Delegation> delegations;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL)
     private List<Application> applications;
 
     @Override

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
@@ -30,7 +30,7 @@ public class User implements UserDetails {
     @ManyToMany(fetch = FetchType.EAGER)
     private Set<Role> authorities;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "user")
     private PersonalData personalData;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
@@ -30,27 +30,27 @@ public class User implements UserDetails {
     @ManyToMany(fetch = FetchType.EAGER)
     private Set<Role> authorities;
 
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "user")
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private PersonalData personalData;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private Permission permissions;
 
     private String position;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private List<Leave> leaves;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private List<Contract> contracts;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private List<Bonus> bonuses;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private List<Delegation> delegations;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
     private List<Application> applications;
 
     @Override

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
@@ -34,6 +34,7 @@ public class User implements UserDetails {
     private PersonalData personalData;
 
     @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "permissions_id")
     private Permission permissions;
 
     private String position;

--- a/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/model/User.java
@@ -30,7 +30,7 @@ public class User implements UserDetails {
     @ManyToMany(fetch = FetchType.EAGER)
     private Set<Role> authorities;
 
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "user", orphanRemoval = true)
+    @OneToOne(cascade = CascadeType.ALL)
     private PersonalData personalData;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/LeaveRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/LeaveRepository.java
@@ -1,22 +1,42 @@
 package com.agh.hr.persistence.repository;
 import com.agh.hr.persistence.model.Leave;
+import com.agh.hr.persistence.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LeaveRepository extends JpaRepository<Leave, Long> {
 
-    List<Leave> findByStartDateEquals(LocalDateTime startDate);
-    List<Leave> findByStartDateBefore(LocalDateTime startDate);
-    List<Leave> findByStartDateAfter(LocalDateTime startDate);
+    @Query("SELECT l FROM Leave l WHERE l.id IS ?1 AND l.user.id IN ?2")
+    Optional<Leave> findById(Long id, List<Long> allowedIds);
 
-    List<Leave> findByEndDateEquals(LocalDateTime endDate);
-    List<Leave> findByEndDateBefore(LocalDateTime endDate);
-    List<Leave> findByEndDateAfter(LocalDateTime endDate);
+    @Query("SELECT l FROM Leave l WHERE l.user.id IN ?1")
+    List<Leave> findAll(List<Long> allowedIds);
 
-    List<Leave> findByPaidEquals(Boolean paid);
+    @Query("SELECT l FROM Leave l WHERE l.startDate IS ?1 AND l.user.id IN ?2")
+    List<Leave> findByStartDateEquals(LocalDateTime startDate, List<Long> allowedIds);
+
+    @Query("SELECT l FROM Leave l WHERE l.startDate< ?1 AND l.user.id IN ?2")
+    List<Leave> findByStartDateBefore(LocalDateTime startDate, List<Long> allowedIds);
+
+    @Query("SELECT l FROM Leave l WHERE l.startDate> ?1 AND l.user.id IN ?2")
+    List<Leave> findByStartDateAfter(LocalDateTime startDate, List<Long> allowedIds);
+
+    @Query("SELECT l FROM Leave l WHERE l.endDate IS ?1 AND l.user.id IN ?2")
+    List<Leave> findByEndDateEquals(LocalDateTime endDate, List<Long> allowedIds);
+
+    @Query("SELECT l FROM Leave l WHERE l.endDate < ?1 AND l.user.id IN ?2")
+    List<Leave> findByEndDateBefore(LocalDateTime endDate, List<Long> allowedIds);
+
+    @Query("SELECT l FROM Leave l WHERE l.endDate > ?1 AND l.user.id IN ?2")
+    List<Leave> findByEndDateAfter(LocalDateTime endDate, List<Long> allowedIds);
+
+    @Query("SELECT l FROM Leave l WHERE l.paid IS ?1 AND l.user.id IN ?2")
+    List<Leave> findByPaidEquals(Boolean paid, List<Long> allowedIds);
 
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/LeaveRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/LeaveRepository.java
@@ -39,4 +39,31 @@ public interface LeaveRepository extends JpaRepository<Leave, Long> {
     @Query("SELECT l FROM Leave l WHERE l.paid IS ?1 AND l.user.id IN ?2")
     List<Leave> findByPaidEquals(Boolean paid, List<Long> allowedIds);
 
+    @Query("SELECT l FROM Leave l WHERE l.id IS ?1")
+    Optional<Leave> findByIdAdmin(Long id);
+
+    @Query("SELECT l FROM Leave l")
+    List<Leave> findAllAdmin();
+
+    @Query("SELECT l FROM Leave l WHERE l.startDate IS ?1")
+    List<Leave> findByStartDateEqualsAdmin(LocalDateTime startDate);
+
+    @Query("SELECT l FROM Leave l WHERE l.startDate< ?1")
+    List<Leave> findByStartDateBeforeAdmin(LocalDateTime startDate);
+
+    @Query("SELECT l FROM Leave l WHERE l.startDate> ?1")
+    List<Leave> findByStartDateAfterAdmin(LocalDateTime startDate);
+
+    @Query("SELECT l FROM Leave l WHERE l.endDate IS ?1")
+    List<Leave> findByEndDateEqualsAdmin(LocalDateTime endDate);
+
+    @Query("SELECT l FROM Leave l WHERE l.endDate < ?1")
+    List<Leave> findByEndDateBeforeAdmin(LocalDateTime endDate);
+
+    @Query("SELECT l FROM Leave l WHERE l.endDate > ?1")
+    List<Leave> findByEndDateAfterAdmin(LocalDateTime endDate);
+
+    @Query("SELECT l FROM Leave l WHERE l.paid IS ?1")
+    List<Leave> findByPaidEqualsAdmin(Boolean paid);
+
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/PersonalDataRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/PersonalDataRepository.java
@@ -24,7 +24,7 @@ public interface PersonalDataRepository extends JpaRepository<PersonalData, Long
     @Query("SELECT d FROM PersonalData d WHERE d.lastname IS ?1 AND d.user.id IN ?2")
     List<PersonalData> findByLastname(String lastname, List<Long> allowedIds);
 
-    @Query("SELECT d FROM User d WHERE d.firstname IS ?1 AND d.lastname IS ?2 AND d.user.id IN ?3")
+    @Query("SELECT d FROM PersonalData d WHERE d.firstname IS ?1 AND d.lastname IS ?2 AND d.user.id IN ?3")
     List<PersonalData> findByFirstnameAndLastname(String firstname,String lastname, List<Long> allowedIds);
 
     @Query("SELECT d FROM PersonalData d WHERE d.address IS ?1 AND d.user.id IN ?2")

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/PersonalDataRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/PersonalDataRepository.java
@@ -12,8 +12,11 @@ import java.util.Optional;
 @Repository
 public interface PersonalDataRepository extends JpaRepository<PersonalData, Long> {
 
+    @Query("SELECT d FROM PersonalData d WHERE d.user.id IN ?1")
+    List<PersonalData> findAll(List<Long> allowedIds);
+
     @Query("SELECT d FROM PersonalData d WHERE d.id IS ?1 AND d.user.id IN ?2")
-    Optional<User> findById(Long id, List<Long> allowedIds);
+    Optional<PersonalData> findById(Long id, List<Long> allowedIds);
 
     @Query("SELECT d FROM PersonalData d WHERE d.firstname IS ?1 AND d.user.id IN ?2")
     List<PersonalData> findByFirstname(String firstname, List<Long> allowedIds);

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/PersonalDataRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/PersonalDataRepository.java
@@ -1,22 +1,43 @@
 package com.agh.hr.persistence.repository;
 import com.agh.hr.persistence.model.PersonalData;
+import com.agh.hr.persistence.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PersonalDataRepository extends JpaRepository<PersonalData, Long> {
 
-    List<PersonalData> findByFirstname(String firstname);
-    List<PersonalData> findByLastname(String lastname);
-    List<PersonalData> findByFirstnameAndLastname(String firstname,String lastname);
-    List<PersonalData> findByAddress(String address);
-    List<PersonalData> findByPhoneNumber(String phoneNumber);
-    List<PersonalData> findByEmail(String email);
-    List<PersonalData> findByBirthdateEquals(LocalDate birthdate);
-    List<PersonalData> findByBirthdateBetween(LocalDate before,LocalDate after);
+    @Query("SELECT d FROM PersonalData d WHERE d.id IS ?1 AND d.user.id IN ?2")
+    Optional<User> findById(Long id, List<Long> allowedIds);
+
+    @Query("SELECT d FROM PersonalData d WHERE d.firstname IS ?1 AND d.user.id IN ?2")
+    List<PersonalData> findByFirstname(String firstname, List<Long> allowedIds);
+
+    @Query("SELECT d FROM PersonalData d WHERE d.lastname IS ?1 AND d.user.id IN ?2")
+    List<PersonalData> findByLastname(String lastname, List<Long> allowedIds);
+
+    @Query("SELECT d FROM User d WHERE d.firstname IS ?1 AND d.lastname IS ?2 AND d.user.id IN ?3")
+    List<PersonalData> findByFirstnameAndLastname(String firstname,String lastname, List<Long> allowedIds);
+
+    @Query("SELECT d FROM PersonalData d WHERE d.address IS ?1 AND d.user.id IN ?2")
+    List<PersonalData> findByAddress(String address, List<Long> allowedIds);
+
+    @Query("SELECT d FROM PersonalData d WHERE d.phoneNumber IS ?1 AND d.user.id IN ?2")
+    List<PersonalData> findByPhoneNumber(String phoneNumber, List<Long> allowedIds);
+
+    @Query("SELECT d FROM PersonalData d WHERE d.email IS ?1 AND d.user.id IN ?2")
+    List<PersonalData> findByEmail(String email, List<Long> allowedIds);
+
+    @Query("SELECT d FROM PersonalData d WHERE d.birthdate IS ?1 AND d.user.id IN ?2")
+    List<PersonalData> findByBirthdateEquals(LocalDate birthdate, List<Long> allowedIds);
+
+    @Query("SELECT d FROM PersonalData d WHERE d.birthdate BETWEEN ?1 AND ?2 AND d.user.id IN ?3")
+    List<PersonalData> findByBirthdateBetween(LocalDate before,LocalDate after, List<Long> allowedIds);
 
 
 

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/UserRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/UserRepository.java
@@ -26,4 +26,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.id IN ?1")
     List<User> findAll(List<Long> allowedIds);
+
+    @Query("SELECT u FROM User u WHERE u.personalData.id IS ?1")
+    Optional<User> getUserByPersonalDataId(Long id);
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/UserRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/UserRepository.java
@@ -29,4 +29,20 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.personalData.id IS ?1")
     Optional<User> getUserByPersonalDataId(Long id);
+
+    @Query("SELECT u FROM User u WHERE u.id IS ?1")
+    Optional<User> findByIdAdmin(Long id);
+
+    @Query("SELECT u FROM User u WHERE u.personalData.firstname IS ?1")
+    List<User> findByFirstnameAdmin(String firstname);
+
+    @Query("SELECT u FROM User u WHERE u.personalData.lastname IS ?1")
+    List<User> findByLastnameAdmin(String lastname);
+
+    @Query("SELECT u FROM User u WHERE u.personalData.firstname IS ?1 AND u.personalData.lastname IS ?2")
+    List<User> findByFirstnameAndLastnameAdmin(String firstname,String lastname);
+
+    @Query("SELECT u FROM User u")
+    List<User> findAllAdmin();
+
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/repository/UserRepository.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.agh.hr.persistence.repository;
 import com.agh.hr.persistence.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,10 +12,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
-    List<User> findByPersonalData_Firstname(String firstname);
+    @Query("SELECT u FROM User u WHERE u.id IS ?1 AND u.id IN ?2")
+    Optional<User> findById(Long id,List<Long> allowedIds);
 
-    List<User> findByPersonalData_Lastname(String lastname);
+    @Query("SELECT u FROM User u WHERE u.personalData.firstname IS ?1 AND u.id IN ?2")
+    List<User> findByPersonalData_Firstname(String firstname,List<Long> allowedIds);
 
-    List<User> findByPersonalData_FirstnameAndPersonalData_Lastname(String firstname,String lastname);
+    @Query("SELECT u FROM User u WHERE u.personalData.lastname IS ?1 AND u.id IN ?2")
+    List<User> findByPersonalData_Lastname(String lastname,List<Long> allowedIds);
 
+    @Query("SELECT u FROM User u WHERE u.personalData.firstname IS ?1 AND u.personalData.lastname IS ?2 AND u.id IN ?3")
+    List<User> findByPersonalData_FirstnameAndPersonalData_Lastname(String firstname,String lastname,List<Long> allowedIds);
+
+    @Query("SELECT u FROM User u WHERE u.id IN ?1")
+    List<User> findAll(List<Long> allowedIds);
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/Auth.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/Auth.java
@@ -1,0 +1,40 @@
+package com.agh.hr.persistence.service;
+import com.agh.hr.persistence.model.Permission;
+import com.agh.hr.persistence.model.User;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Auth {
+
+    public static List<Long> getReadIds(User userAuth) {
+        List<Long> allowedIds=new ArrayList<>();
+        allowedIds.add(userAuth.getId());
+        Permission permission=userAuth.getPermissions();
+        if(permission!=null) {
+            List<Long> readList = permission.getRead();
+            if (readList != null)
+                allowedIds.addAll(readList);
+        }
+        return allowedIds;
+    }
+
+    public static List<Long> getWriteIds(User userAuth) {
+        Permission permission=userAuth.getPermissions();
+        if(permission!=null) {
+            List<Long> allowedIds = permission.getWrite();
+            if (allowedIds != null)
+                return allowedIds;
+        }
+        return Collections.emptyList();
+    }
+
+    public static boolean getAdd(User userAuth) {
+        Permission permission=userAuth.getPermissions();
+        if(permission!=null)
+            return(permission.getAdd());
+        else
+            return false;
+    }
+
+}

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/LeaveService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/LeaveService.java
@@ -1,8 +1,11 @@
 package com.agh.hr.persistence.service;
 
 import com.agh.hr.persistence.model.Leave;
+import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.repository.LeaveRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,50 +25,60 @@ public class LeaveService {
         this.leaveRepository=leaveRepository;
     }
 
-    public Optional<Leave> saveLeave(Leave leave) {
+    public Optional<Leave> saveLeave(Leave leave, User userAuth,boolean isNew) {
+        if(isNew&&!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(leave.getUser().getId())))
+            return Optional.empty();
+        else if(!isNew &&!(Auth.getWriteIds(userAuth).contains(leave.getUser().getId())))
+            return Optional.empty();
         try {
             return Optional.of(leaveRepository.save(leave));
         }catch(Exception e){return Optional.empty();}
     }
 
-    public Optional<Leave> getById(Long id) {
-        return leaveRepository.findById(id);
+    public Optional<Leave> getById(Long id,User userAuth) {
+        return leaveRepository.findById(id,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getAllLeaves() {
-        return leaveRepository.findAll();
+    public List<Leave> getAllLeaves(User userAuth) {
+        return leaveRepository.findAll(Auth.getReadIds(userAuth));
     }
 
-    public void deleteLeave(Long leaveId) {
-            leaveRepository.deleteById(leaveId);
+    public ResponseEntity<Void> deleteLeave(Long leaveId,User userAuth) {
+        Optional<Leave> leave=leaveRepository.findById(leaveId);
+        if(!leave.isPresent())
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        if(!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(leave.get().getUser().getId())))
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        leaveRepository.deleteById(leaveId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    public List<Leave> getByStartDateEquals(LocalDateTime startDate) {
-        return leaveRepository.findByStartDateEquals(startDate);
+    public List<Leave> getByStartDateEquals(LocalDateTime startDate,User userAuth) {
+        return leaveRepository.findByStartDateEquals(startDate,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByStartDateBefore(LocalDateTime before) {
-        return leaveRepository.findByStartDateBefore(before);
+    public List<Leave> getByStartDateBefore(LocalDateTime before,User userAuth) {
+        return leaveRepository.findByStartDateBefore(before,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByStartDateAfter(LocalDateTime after) {
-        return leaveRepository.findByStartDateAfter(after);
+    public List<Leave> getByStartDateAfter(LocalDateTime after,User userAuth) {
+        return leaveRepository.findByStartDateAfter(after,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByEndDateEquals(LocalDateTime endDate) {
-        return leaveRepository.findByEndDateEquals(endDate);
+    public List<Leave> getByEndDateEquals(LocalDateTime endDate,User userAuth) {
+        return leaveRepository.findByEndDateEquals(endDate,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByEndDateBefore(LocalDateTime before) {
-        return leaveRepository.findByEndDateBefore(before);
+    public List<Leave> getByEndDateBefore(LocalDateTime before,User userAuth) {
+        return leaveRepository.findByEndDateBefore(before,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByEndDateAfter(LocalDateTime after) {
-        return leaveRepository.findByEndDateAfter(after);
+    public List<Leave> getByEndDateAfter(LocalDateTime after,User userAuth) {
+        return leaveRepository.findByEndDateAfter(after,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByPaidEquals(boolean paid) {
-        return leaveRepository.findByPaidEquals(paid);
+    public List<Leave> getByPaidEquals(boolean paid,User userAuth) {
+        return leaveRepository.findByPaidEquals(paid,Auth.getReadIds(userAuth));
     }
     
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/LeaveService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/LeaveService.java
@@ -21,18 +21,22 @@ public class LeaveService {
 
 
     private final LeaveRepository leaveRepository;
+    private final RoleService roleService;
 
     @Autowired
-    public LeaveService(LeaveRepository leaveRepository){
+    public LeaveService(LeaveRepository leaveRepository,RoleService roleService){
         this.leaveRepository=leaveRepository;
+        this.roleService=roleService;
+
     }
 
     public Optional<Leave> saveLeave(Leave leave,boolean isNew) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
-        if(isNew&&!(Auth.getAdd(userAuth)))
-            return Optional.empty();
-        else if(!isNew &&!(Auth.getWriteIds(userAuth).contains(leave.getUser().getId())))
-            return Optional.empty();
+        if(!userAuth.getAuthorities().contains(roleService.adminRole()))
+            if(isNew&&!(Auth.getAdd(userAuth)))
+                return Optional.empty();
+            else if(!isNew &&!(Auth.getWriteIds(userAuth).contains(leave.getUser().getId())))
+                return Optional.empty();
         try {
             return Optional.of(leaveRepository.save(leave));
         }catch(Exception e){return Optional.empty();}
@@ -40,11 +44,15 @@ public class LeaveService {
 
     public Optional<Leave> getById(Long id) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByIdAdmin(id);
         return leaveRepository.findById(id,Auth.getReadIds(userAuth));
     }
 
     public List<Leave> getAllLeaves() {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findAllAdmin();
         return leaveRepository.findAll(Auth.getReadIds(userAuth));
     }
 
@@ -53,44 +61,59 @@ public class LeaveService {
         Optional<Leave> leave=leaveRepository.findById(leaveId);
         if(!leave.isPresent())
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        if(!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(leave.get().getUser().getId())))
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        if(!userAuth.getAuthorities().contains(roleService.adminRole()))
+            if(!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(leave.get().getUser().getId())))
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         leaveRepository.deleteById(leaveId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     public List<Leave> getByStartDateEquals(LocalDateTime startDate) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByStartDateEqualsAdmin(startDate);
         return leaveRepository.findByStartDateEquals(startDate,Auth.getReadIds(userAuth));
     }
 
     public List<Leave> getByStartDateBefore(LocalDateTime before) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByStartDateBeforeAdmin(before);
         return leaveRepository.findByStartDateBefore(before,Auth.getReadIds(userAuth));
     }
 
     public List<Leave> getByStartDateAfter(LocalDateTime after) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByStartDateAfterAdmin(after);
         return leaveRepository.findByStartDateAfter(after,Auth.getReadIds(userAuth));
     }
 
     public List<Leave> getByEndDateEquals(LocalDateTime endDate) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByEndDateEqualsAdmin(endDate);
         return leaveRepository.findByEndDateEquals(endDate,Auth.getReadIds(userAuth));
     }
 
     public List<Leave> getByEndDateBefore(LocalDateTime before) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByEndDateBeforeAdmin(before);
         return leaveRepository.findByEndDateBefore(before,Auth.getReadIds(userAuth));
     }
 
     public List<Leave> getByEndDateAfter(LocalDateTime after) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByEndDateAfterAdmin(after);
         return leaveRepository.findByEndDateAfter(after,Auth.getReadIds(userAuth));
     }
 
     public List<Leave> getByPaidEquals(boolean paid) {
         val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(userAuth.getAuthorities().contains(roleService.adminRole()))
+            return leaveRepository.findByPaidEqualsAdmin(paid);
         return leaveRepository.findByPaidEquals(paid,Auth.getReadIds(userAuth));
     }
     

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/LeaveService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/LeaveService.java
@@ -3,9 +3,11 @@ package com.agh.hr.persistence.service;
 import com.agh.hr.persistence.model.Leave;
 import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.repository.LeaveRepository;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,8 +27,9 @@ public class LeaveService {
         this.leaveRepository=leaveRepository;
     }
 
-    public Optional<Leave> saveLeave(Leave leave, User userAuth,boolean isNew) {
-        if(isNew&&!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(leave.getUser().getId())))
+    public Optional<Leave> saveLeave(Leave leave,boolean isNew) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        if(isNew&&!(Auth.getAdd(userAuth)))
             return Optional.empty();
         else if(!isNew &&!(Auth.getWriteIds(userAuth).contains(leave.getUser().getId())))
             return Optional.empty();
@@ -35,15 +38,18 @@ public class LeaveService {
         }catch(Exception e){return Optional.empty();}
     }
 
-    public Optional<Leave> getById(Long id,User userAuth) {
+    public Optional<Leave> getById(Long id) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findById(id,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getAllLeaves(User userAuth) {
+    public List<Leave> getAllLeaves() {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findAll(Auth.getReadIds(userAuth));
     }
 
-    public ResponseEntity<Void> deleteLeave(Long leaveId,User userAuth) {
+    public ResponseEntity<Void> deleteLeave(Long leaveId) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         Optional<Leave> leave=leaveRepository.findById(leaveId);
         if(!leave.isPresent())
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
@@ -53,31 +59,38 @@ public class LeaveService {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    public List<Leave> getByStartDateEquals(LocalDateTime startDate,User userAuth) {
+    public List<Leave> getByStartDateEquals(LocalDateTime startDate) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findByStartDateEquals(startDate,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByStartDateBefore(LocalDateTime before,User userAuth) {
+    public List<Leave> getByStartDateBefore(LocalDateTime before) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findByStartDateBefore(before,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByStartDateAfter(LocalDateTime after,User userAuth) {
+    public List<Leave> getByStartDateAfter(LocalDateTime after) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findByStartDateAfter(after,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByEndDateEquals(LocalDateTime endDate,User userAuth) {
+    public List<Leave> getByEndDateEquals(LocalDateTime endDate) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findByEndDateEquals(endDate,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByEndDateBefore(LocalDateTime before,User userAuth) {
+    public List<Leave> getByEndDateBefore(LocalDateTime before) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findByEndDateBefore(before,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByEndDateAfter(LocalDateTime after,User userAuth) {
+    public List<Leave> getByEndDateAfter(LocalDateTime after) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findByEndDateAfter(after,Auth.getReadIds(userAuth));
     }
 
-    public List<Leave> getByPaidEquals(boolean paid,User userAuth) {
+    public List<Leave> getByPaidEquals(boolean paid) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return leaveRepository.findByPaidEquals(paid,Auth.getReadIds(userAuth));
     }
     

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/PermissionService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/PermissionService.java
@@ -44,5 +44,9 @@ public class PermissionService {
         return permissionRepository.findByAddEquals(add);
     }
 
+    public boolean isAllowedToGet(long id){
 
+
+        return false;
+    }
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/PersonalDataService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/PersonalDataService.java
@@ -1,6 +1,7 @@
 package com.agh.hr.persistence.service;
 
 import com.agh.hr.persistence.model.PersonalData;
+import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.repository.PersonalDataRepository;
 import com.agh.hr.persistence.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,47 +30,47 @@ public class PersonalDataService {
         }catch(Exception e){return Optional.empty();}
     }
 
-    public Optional<PersonalData> getById(Long id) {
-        return personalDataRepository.findById(id);
+    public Optional<PersonalData> getById(Long id, User userAuth) {
+        return personalDataRepository.findById(id,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getAllPersonalData() {
-        return personalDataRepository.findAll();
+    public List<PersonalData> getAllPersonalData(User userAuth) {
+        return personalDataRepository.findAll(Auth.getReadIds(userAuth));
     }
 
     public void deletePersonalData(Long dataId) {
             personalDataRepository.deleteById(dataId);
     }
 
-    public List<PersonalData> getByFirstname(String firstname) {
-        return personalDataRepository.findByFirstname(firstname);
+    public List<PersonalData> getByFirstname(String firstname,User userAuth) {
+        return personalDataRepository.findByFirstname(firstname,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByLastname(String lastname) {
-        return personalDataRepository.findByLastname(lastname);
+    public List<PersonalData> getByLastname(String lastname,User userAuth) {
+        return personalDataRepository.findByLastname(lastname,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByFullName(String firstname,String lastname) {
-        return personalDataRepository.findByFirstnameAndLastname(firstname,lastname);
+    public List<PersonalData> getByFullName(String firstname,String lastname,User userAuth) {
+        return personalDataRepository.findByFirstnameAndLastname(firstname,lastname,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByAddress(String address) {
-        return personalDataRepository.findByAddress(address);
+    public List<PersonalData> getByAddress(String address,User userAuth) {
+        return personalDataRepository.findByAddress(address,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByPhone(String phone) {
-        return personalDataRepository.findByPhoneNumber(phone);
+    public List<PersonalData> getByPhone(String phone,User userAuth) {
+        return personalDataRepository.findByPhoneNumber(phone,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByEmail(String email) {
-        return personalDataRepository.findByEmail(email);
+    public List<PersonalData> getByEmail(String email,User userAuth) {
+        return personalDataRepository.findByEmail(email,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByBirthdateEquals(LocalDate date) {
-        return personalDataRepository.findByBirthdateEquals(date);
+    public List<PersonalData> getByBirthdateEquals(LocalDate date,User userAuth) {
+        return personalDataRepository.findByBirthdateEquals(date,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByBirthdateBetween(LocalDate before,LocalDate after) {
-        return personalDataRepository.findByBirthdateBetween(before,after);
+    public List<PersonalData> getByBirthdateBetween(LocalDate before,LocalDate after,User userAuth) {
+        return personalDataRepository.findByBirthdateBetween(before,after,Auth.getReadIds(userAuth));
     }
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/PersonalDataService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/PersonalDataService.java
@@ -4,9 +4,11 @@ import com.agh.hr.persistence.model.PersonalData;
 import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.repository.PersonalDataRepository;
 import com.agh.hr.persistence.repository.UserRepository;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,26 +30,30 @@ public class PersonalDataService {
         this.userRepository=userRepository;
     }
 
-    public Optional<PersonalData> savePersonalData(PersonalData data, User userAuth) {
+    public Optional<PersonalData> savePersonalData(PersonalData data,boolean isNew) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         Optional<User> user=userRepository.getUserByPersonalDataId(data.getId());
-        if(!user.isPresent())
+        if(isNew&&!(Auth.getAdd(userAuth)))
             return Optional.empty();
-        if(!(Auth.getWriteIds(userAuth).contains(user.get().getId())))
+        else if(!isNew &&user.isPresent()&&!(Auth.getWriteIds(userAuth).contains(user.get().getId())))
             return Optional.empty();
         try {
             return Optional.of(personalDataRepository.save(data));
         }catch(Exception e){return Optional.empty();}
     }
 
-    public Optional<PersonalData> getById(Long id, User userAuth) {
+    public Optional<PersonalData> getById(Long id) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findById(id,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getAllPersonalData(User userAuth) {
+    public List<PersonalData> getAllPersonalData() {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findAll(Auth.getReadIds(userAuth));
     }
 
-    public ResponseEntity<Void> deletePersonalData(Long dataId, User userAuth) {
+    public ResponseEntity<Void> deletePersonalData(Long dataId) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         Optional<User> user=userRepository.getUserByPersonalDataId(dataId);
         if(!user.isPresent())
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
@@ -57,35 +63,43 @@ public class PersonalDataService {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    public List<PersonalData> getByFirstname(String firstname,User userAuth) {
+    public List<PersonalData> getByFirstname(String firstname) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByFirstname(firstname,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByLastname(String lastname,User userAuth) {
+    public List<PersonalData> getByLastname(String lastname) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByLastname(lastname,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByFullName(String firstname,String lastname,User userAuth) {
+    public List<PersonalData> getByFullName(String firstname,String lastname) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByFirstnameAndLastname(firstname,lastname,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByAddress(String address,User userAuth) {
+    public List<PersonalData> getByAddress(String address) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByAddress(address,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByPhone(String phone,User userAuth) {
+    public List<PersonalData> getByPhone(String phone) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByPhoneNumber(phone,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByEmail(String email,User userAuth) {
+    public List<PersonalData> getByEmail(String email) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByEmail(email,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByBirthdateEquals(LocalDate date,User userAuth) {
+    public List<PersonalData> getByBirthdateEquals(LocalDate date) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByBirthdateEquals(date,Auth.getReadIds(userAuth));
     }
 
-    public List<PersonalData> getByBirthdateBetween(LocalDate before,LocalDate after,User userAuth) {
+    public List<PersonalData> getByBirthdateBetween(LocalDate before,LocalDate after) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return personalDataRepository.findByBirthdateBetween(before,after,Auth.getReadIds(userAuth));
     }
 }

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
@@ -29,12 +29,17 @@ public class UserService {
 
     public Optional<User> saveUser(User user,User userAuth,boolean isNew) {
 
-        if(isNew&&!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(user.getId())))
+        if(isNew&&!(Auth.getAdd(userAuth)))
             return Optional.empty();
         else if(!isNew &&!(Auth.getWriteIds(userAuth).contains(user.getId())))
             return Optional.empty();
         try {
-                return Optional.of(userRepository.save(user));
+                val result= Optional.of(userRepository.save(user));
+                if(isNew) {
+                    userAuth.getPermissions().addToWrite(result.get().getId());
+                    val newUserAuth = userRepository.save(userAuth);
+                }
+                return result;
         } catch(Exception e) {
             return Optional.empty();
         }

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,11 +22,12 @@ public class UserService {
     @Autowired
     public UserService(UserRepository userRepository){
         this.userRepository=userRepository;
+
     }
 
     public Optional<User> saveUser(User user) {
         try {
-            return Optional.of(userRepository.save(user));
+                return Optional.of(userRepository.save(user));
         } catch(Exception e) {
             return Optional.empty();
         }
@@ -35,28 +37,28 @@ public class UserService {
         return userRepository.findByUsername(username);
     }
 
-    public Optional<User> getById(Long id) {
-        return userRepository.findById(id);
+    public Optional<User> getById(Long id,User userAuth) {
+        return userRepository.findById(id,Auth.getReadIds(userAuth));
     }
 
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    public List<User> getAllUsers(User userAuth) {
+        return userRepository.findAll(Auth.getReadIds(userAuth));
     }
 
     public void deleteUser(Long UserId) {
             userRepository.deleteById(UserId);
     }
 
-    public List<User> getByFirstname(String firstname) {
-        return userRepository.findByPersonalData_Firstname(firstname);
+    public List<User> getByFirstname(String firstname,User userAuth) {
+        return userRepository.findByPersonalData_Firstname(firstname,Auth.getReadIds(userAuth));
     }
 
-    public List<User> getByLastname(String lastname) {
-        return userRepository.findByPersonalData_Lastname(lastname);
+    public List<User> getByLastname(String lastname,User userAuth) {
+        return userRepository.findByPersonalData_Lastname(lastname,Auth.getReadIds(userAuth));
     }
 
-    public List<User> getByFullName(String firstname,String lastname) {
-        return userRepository.findByPersonalData_FirstnameAndPersonalData_Lastname(firstname,lastname);
+    public List<User> getByFullName(String firstname,String lastname,User userAuth) {
+        return userRepository.findByPersonalData_FirstnameAndPersonalData_Lastname(firstname,lastname,Auth.getReadIds(userAuth));
     }
 
 

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
@@ -4,6 +4,8 @@ import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.repository.UserRepository;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +27,12 @@ public class UserService {
 
     }
 
-    public Optional<User> saveUser(User user) {
+    public Optional<User> saveUser(User user,User userAuth,boolean isNew) {
+
+        if(isNew&&!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(user.getId())))
+            return Optional.empty();
+        else if(!isNew &&!(Auth.getWriteIds(userAuth).contains(user.getId())))
+            return Optional.empty();
         try {
                 return Optional.of(userRepository.save(user));
         } catch(Exception e) {
@@ -45,8 +52,11 @@ public class UserService {
         return userRepository.findAll(Auth.getReadIds(userAuth));
     }
 
-    public void deleteUser(Long UserId) {
-            userRepository.deleteById(UserId);
+    public ResponseEntity<Void> deleteUser(Long userId,User userAuth) {
+        if(!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(userId)))
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        userRepository.deleteById(userId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     public List<User> getByFirstname(String firstname,User userAuth) {

--- a/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
+++ b/spring-app/src/main/java/com/agh/hr/persistence/service/UserService.java
@@ -6,6 +6,7 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,8 +28,8 @@ public class UserService {
 
     }
 
-    public Optional<User> saveUser(User user,User userAuth,boolean isNew) {
-
+    public Optional<User> saveUser(User user,boolean isNew) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         if(isNew&&!(Auth.getAdd(userAuth)))
             return Optional.empty();
         else if(!isNew &&!(Auth.getWriteIds(userAuth).contains(user.getId())))
@@ -49,30 +50,36 @@ public class UserService {
         return userRepository.findByUsername(username);
     }
 
-    public Optional<User> getById(Long id,User userAuth) {
+    public Optional<User> getById(Long id) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return userRepository.findById(id,Auth.getReadIds(userAuth));
     }
 
-    public List<User> getAllUsers(User userAuth) {
+    public List<User> getAllUsers() {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return userRepository.findAll(Auth.getReadIds(userAuth));
     }
 
-    public ResponseEntity<Void> deleteUser(Long userId,User userAuth) {
+    public ResponseEntity<Void> deleteUser(Long userId) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         if(!(Auth.getAdd(userAuth)&&Auth.getWriteIds(userAuth).contains(userId)))
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         userRepository.deleteById(userId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    public List<User> getByFirstname(String firstname,User userAuth) {
+    public List<User> getByFirstname(String firstname) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return userRepository.findByPersonalData_Firstname(firstname,Auth.getReadIds(userAuth));
     }
 
-    public List<User> getByLastname(String lastname,User userAuth) {
+    public List<User> getByLastname(String lastname) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return userRepository.findByPersonalData_Lastname(lastname,Auth.getReadIds(userAuth));
     }
 
-    public List<User> getByFullName(String firstname,String lastname,User userAuth) {
+    public List<User> getByFullName(String firstname,String lastname) {
+        val userAuth=(User)(SecurityContextHolder.getContext().getAuthentication().getPrincipal());
         return userRepository.findByPersonalData_FirstnameAndPersonalData_Lastname(firstname,lastname,Auth.getReadIds(userAuth));
     }
 

--- a/spring-app/src/test/java/com/agh/hr/UserControllerTests.java
+++ b/spring-app/src/test/java/com/agh/hr/UserControllerTests.java
@@ -65,7 +65,7 @@ public class UserControllerTests {
 
     @Test
     void testSuccessCreateUser() {
-        when(userService.saveUser(userTest)).thenReturn(Optional.of(userTest));
+        when(userService.saveUser(userTest,userTest,true)).thenReturn(Optional.of(userTest));
         when(converters.DTOToUser(userTestDTO)).thenReturn(userTest);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
 
@@ -81,7 +81,7 @@ public class UserControllerTests {
 
     @Test
     void testFailCreateUser() {
-        when(userService.saveUser(userTest)).thenReturn(Optional.empty());
+        when(userService.saveUser(userTest,userTest,true)).thenReturn(Optional.empty());
         when(converters.DTOToUser(userTestDTO)).thenReturn(userTest);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
 
@@ -230,7 +230,7 @@ public class UserControllerTests {
     @Test
     void testSuccessUpdateUser() {
 
-        when(userService.saveUser(userTest)).thenReturn(Optional.of(userTest));
+        when(userService.saveUser(userTest,userTest,false)).thenReturn(Optional.of(userTest));
         when(userService.getById(10L,userTest)).thenReturn(Optional.of(userTest));
 
         assertEquals(202,userController.updateUser(userTestDTO,userTest).getStatusCodeValue());
@@ -241,7 +241,7 @@ public class UserControllerTests {
     @Test
     void testFailUpdateUser() {
 
-        when(userService.saveUser(userTest)).thenReturn(Optional.of(userTest));
+        when(userService.saveUser(userTest,userTest,false)).thenReturn(Optional.of(userTest));
         when(userService.getById(20L,userTest)).thenReturn(Optional.of(userTest));
 
         assertEquals(404,userController.updateUser(userTestDTO,userTest).getStatusCodeValue());

--- a/spring-app/src/test/java/com/agh/hr/UserControllerTests.java
+++ b/spring-app/src/test/java/com/agh/hr/UserControllerTests.java
@@ -6,6 +6,7 @@ import com.agh.hr.controllers.UserController;
 import com.agh.hr.persistence.dto.Converters;
 import com.agh.hr.persistence.dto.PersonalDataDTO;
 import com.agh.hr.persistence.dto.UserDTO;
+import com.agh.hr.persistence.model.Permission;
 import com.agh.hr.persistence.model.PersonalData;
 import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.service.UserService;
@@ -40,10 +41,15 @@ public class UserControllerTests {
                 .firstname("Susan")
                 .lastname("Barrow")
                 .build();
+        val permission=Permission.builder()
+                .add(true).build();
+        permission.addToWrite(10L);
+        permission.addToRead(10L);
 
         this.userTest = User.builder()
                 .id(10L)
                 .personalData(personalData)
+                .permissions(permission)
                 .build();
 
         val personalDataDTO= PersonalDataDTO.builder()
@@ -64,9 +70,9 @@ public class UserControllerTests {
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
 
         assertAll(
-                ()->assertEquals(200,userController.insertUser(userTestDTO).getStatusCodeValue()),
-                ()->assertNotNull(userController.insertUser(userTestDTO).getBody()),
-                ()->assertEquals(userController.insertUser(userTestDTO).getBody(),userTestDTO)
+                ()->assertEquals(200,userController.insertUser(userTestDTO,userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.insertUser(userTestDTO,userTest).getBody()),
+                ()->assertEquals(userController.insertUser(userTestDTO,userTest).getBody(),userTestDTO)
         );
 
         verify(converters, times(3)).userToDTO(userTest);
@@ -80,8 +86,8 @@ public class UserControllerTests {
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
 
         assertAll(
-                ()->assertEquals(400,userController.insertUser(userTestDTO).getStatusCodeValue()),
-                ()->assertNull(userController.insertUser(userTestDTO).getBody())
+                ()->assertEquals(400,userController.insertUser(userTestDTO,userTest).getStatusCodeValue()),
+                ()->assertNull(userController.insertUser(userTestDTO,userTest).getBody())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -98,11 +104,11 @@ public class UserControllerTests {
 
 
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
-        when(userService.getAllUsers()).thenReturn(userList);
+        when(userService.getAllUsers(userTest)).thenReturn(userList);
         assertAll(
-                ()->assertEquals(200,userController.getAllUsers().getStatusCodeValue()),
-                ()->assertNotNull(userController.getAllUsers().getBody()),
-                ()->assertTrue(userController.getAllUsers().getBody().containsAll(userDTOList))
+                ()->assertEquals(200,userController.getAllUsers(userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.getAllUsers(userTest).getBody()),
+                ()->assertTrue(userController.getAllUsers(userTest).getBody().containsAll(userDTOList))
         );
         verify(converters, times(30)).userToDTO(userTest);
     }
@@ -111,11 +117,11 @@ public class UserControllerTests {
     void testSuccessGetUserById() {
 
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
-        when(userService.getById(10L)).thenReturn(Optional.of(userTest));
+        when(userService.getById(10L,userTest)).thenReturn(Optional.of(userTest));
         assertAll(
-                ()->assertEquals(200,userController.getUserById(10L).getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserById(10L).getBody()),
-                ()->assertEquals(10L,Objects.requireNonNull(userController.getUserById(10L)
+                ()->assertEquals(200,userController.getUserById(10L,userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserById(10L,userTest).getBody()),
+                ()->assertEquals(10L,Objects.requireNonNull(userController.getUserById(10L,userTest)
                         .getBody()).getId().longValue())
         );
         verify(converters, times(3)).userToDTO(userTest);
@@ -125,10 +131,10 @@ public class UserControllerTests {
     void testFailGetUserById() {
 
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
-        when(userService.getById(10L)).thenReturn(Optional.of(userTest));
+        when(userService.getById(10L,userTest)).thenReturn(Optional.of(userTest));
         assertAll(
-                ()->assertEquals(404,userController.getUserById(20L).getStatusCodeValue()),
-                ()->assertNull(userController.getUserById(20L).getBody())
+                ()->assertEquals(404,userController.getUserById(20L,userTest).getStatusCodeValue()),
+                ()->assertNull(userController.getUserById(20L,userTest).getBody())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -138,13 +144,13 @@ public class UserControllerTests {
         List<User> userList=new ArrayList<>();
         userList.add(userTest);
 
-        when(userService.getByFirstname("Susan")).thenReturn(userList);
+        when(userService.getByFirstname("Susan",userTest)).thenReturn(userList);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
         assertAll(
-                ()->assertEquals(200,userController.getUserByFirstname("Susan").getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByFirstname("Susan").getBody()),
-                ()->assertFalse(Objects.requireNonNull(userController.getUserByFirstname("Susan").getBody()).isEmpty()),
-                ()->assertEquals("Susan",Objects.requireNonNull(userController.getUserByFirstname("Susan")
+                ()->assertEquals(200,userController.getUserByFirstname("Susan",userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByFirstname("Susan",userTest).getBody()),
+                ()->assertFalse(Objects.requireNonNull(userController.getUserByFirstname("Susan",userTest).getBody()).isEmpty()),
+                ()->assertEquals("Susan",Objects.requireNonNull(userController.getUserByFirstname("Susan",userTest)
                         .getBody()).get(0).getPersonalData().getFirstname())
         );
         verify(converters, times(4)).userToDTO(userTest);
@@ -152,10 +158,10 @@ public class UserControllerTests {
     @Test
     void testFailGetUserByFirstname() {
         List<User> emptyUserList=new ArrayList<>();
-        when(userService.getByFirstname("Sussan")).thenReturn(emptyUserList);
+        when(userService.getByFirstname("Sussan",userTest)).thenReturn(emptyUserList);
         assertAll(
-                ()->assertNotNull(userController.getUserByFirstname("Sussan")),
-                ()->assertTrue(Objects.requireNonNull(userController.getUserByFirstname("Sussan").getBody()).isEmpty())
+                ()->assertNotNull(userController.getUserByFirstname("Sussan",userTest)),
+                ()->assertTrue(Objects.requireNonNull(userController.getUserByFirstname("Sussan",userTest).getBody()).isEmpty())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -165,13 +171,13 @@ public class UserControllerTests {
         List<User> userList=new ArrayList<>();
         userList.add(userTest);
 
-        when(userService.getByLastname("Barrow")).thenReturn(userList);
+        when(userService.getByLastname("Barrow",userTest)).thenReturn(userList);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
         assertAll(
-                ()->assertEquals(200,userController.getUserByLastname("Barrow").getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByLastname("Barrow").getBody()),
-                ()->assertFalse(Objects.requireNonNull(userController.getUserByLastname("Barrow").getBody()).isEmpty()),
-                ()->assertEquals("Barrow",Objects.requireNonNull(userController.getUserByLastname("Barrow")
+                ()->assertEquals(200,userController.getUserByLastname("Barrow",userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByLastname("Barrow",userTest).getBody()),
+                ()->assertFalse(Objects.requireNonNull(userController.getUserByLastname("Barrow",userTest).getBody()).isEmpty()),
+                ()->assertEquals("Barrow",Objects.requireNonNull(userController.getUserByLastname("Barrow",userTest)
                         .getBody()).get(0).getPersonalData().getLastname())
         );
         verify(converters, times(4)).userToDTO(userTest);
@@ -181,11 +187,11 @@ public class UserControllerTests {
     @Test
     void testFailGetUserByLastname() {
         List<User> emptyUserList=new ArrayList<>();
-        when(userService.getByLastname("Sussan")).thenReturn(emptyUserList);
+        when(userService.getByLastname("Sussan",userTest)).thenReturn(emptyUserList);
         assertAll(
-                ()->assertEquals(200,userController.getUserByLastname("Sussan").getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByLastname("Sussan")),
-                ()->assertTrue(Objects.requireNonNull(userController.getUserByLastname("Sussan").getBody()).isEmpty())
+                ()->assertEquals(200,userController.getUserByLastname("Sussan",userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByLastname("Sussan",userTest)),
+                ()->assertTrue(Objects.requireNonNull(userController.getUserByLastname("Sussan",userTest).getBody()).isEmpty())
         );
         verify(converters, times(0)).userToDTO(userTest);
 
@@ -195,16 +201,16 @@ public class UserControllerTests {
     void testSuccessGetUserByFullname() {
         List<User> userList=new ArrayList<>();
         userList.add(userTest);
-        when(userService.getByFullName("Susan","Barrow")).thenReturn(userList);
+        when(userService.getByFullName("Susan","Barrow",userTest)).thenReturn(userList);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
         assertAll(
-                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow").getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow")),
+                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow",userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow",userTest)),
                 ()->assertEquals("Susan",Objects.requireNonNull(userController
-                        .getUserByFullName("Susan","Barrow").getBody())
+                        .getUserByFullName("Susan","Barrow",userTest).getBody())
                         .get(0).getPersonalData().getFirstname()),
                 ()->assertEquals("Barrow",Objects.requireNonNull(userController
-                        .getUserByFullName("Susan","Barrow").getBody()).get(0).getPersonalData().getLastname())
+                        .getUserByFullName("Susan","Barrow",userTest).getBody()).get(0).getPersonalData().getLastname())
         );
         verify(converters, times(4)).userToDTO(userTest);
     }
@@ -212,11 +218,11 @@ public class UserControllerTests {
     @Test
     void testFailGetUserByFullname() {
         List<User> emptyUserList=new ArrayList<>();
-        when(userService.getByFullName("Susan","Barrow")).thenReturn(emptyUserList);
+        when(userService.getByFullName("Susan","Barrow",userTest)).thenReturn(emptyUserList);
         assertAll(
-                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow").getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow")),
-                ()->assertTrue(Objects.requireNonNull(userController.getUserByFullName("Susan","Barrow").getBody()).isEmpty())
+                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow",userTest).getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow",userTest)),
+                ()->assertTrue(Objects.requireNonNull(userController.getUserByFullName("Susan","Barrow",userTest).getBody()).isEmpty())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -225,9 +231,9 @@ public class UserControllerTests {
     void testSuccessUpdateUser() {
 
         when(userService.saveUser(userTest)).thenReturn(Optional.of(userTest));
-        when(userService.getById(10L)).thenReturn(Optional.of(userTest));
+        when(userService.getById(10L,userTest)).thenReturn(Optional.of(userTest));
 
-        assertEquals(202,userController.updateUser(userTestDTO).getStatusCodeValue());
+        assertEquals(202,userController.updateUser(userTestDTO,userTest).getStatusCodeValue());
         verify(converters, times(1)).updateUserWithDTO(userTestDTO,userTest);
 
     }
@@ -236,9 +242,9 @@ public class UserControllerTests {
     void testFailUpdateUser() {
 
         when(userService.saveUser(userTest)).thenReturn(Optional.of(userTest));
-        when(userService.getById(20L)).thenReturn(Optional.of(userTest));
+        when(userService.getById(20L,userTest)).thenReturn(Optional.of(userTest));
 
-        assertEquals(404,userController.updateUser(userTestDTO).getStatusCodeValue());
+        assertEquals(404,userController.updateUser(userTestDTO,userTest).getStatusCodeValue());
         verify(converters, times(0)).updateUserWithDTO(userTestDTO,userTest);
 
     }

--- a/spring-app/src/test/java/com/agh/hr/UserControllerTests.java
+++ b/spring-app/src/test/java/com/agh/hr/UserControllerTests.java
@@ -15,8 +15,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+
+import java.security.Principal;
 import java.util.*;
 
 public class UserControllerTests {
@@ -32,6 +33,7 @@ public class UserControllerTests {
 
     private User userTest;
     private UserDTO userTestDTO;
+    private Principal principal;
 
     @BeforeEach
     public void setup() {
@@ -41,15 +43,10 @@ public class UserControllerTests {
                 .firstname("Susan")
                 .lastname("Barrow")
                 .build();
-        val permission=Permission.builder()
-                .add(true).build();
-        permission.addToWrite(10L);
-        permission.addToRead(10L);
 
         this.userTest = User.builder()
                 .id(10L)
                 .personalData(personalData)
-                .permissions(permission)
                 .build();
 
         val personalDataDTO= PersonalDataDTO.builder()
@@ -65,14 +62,14 @@ public class UserControllerTests {
 
     @Test
     void testSuccessCreateUser() {
-        when(userService.saveUser(userTest,userTest,true)).thenReturn(Optional.of(userTest));
+        when(userService.saveUser(userTest,true)).thenReturn(Optional.of(userTest));
         when(converters.DTOToUser(userTestDTO)).thenReturn(userTest);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
 
         assertAll(
-                ()->assertEquals(200,userController.insertUser(userTestDTO,userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.insertUser(userTestDTO,userTest).getBody()),
-                ()->assertEquals(userController.insertUser(userTestDTO,userTest).getBody(),userTestDTO)
+                ()->assertEquals(200,userController.insertUser(userTestDTO).getStatusCodeValue()),
+                ()->assertNotNull(userController.insertUser(userTestDTO).getBody()),
+                ()->assertEquals(userController.insertUser(userTestDTO).getBody(),userTestDTO)
         );
 
         verify(converters, times(3)).userToDTO(userTest);
@@ -81,13 +78,13 @@ public class UserControllerTests {
 
     @Test
     void testFailCreateUser() {
-        when(userService.saveUser(userTest,userTest,true)).thenReturn(Optional.empty());
+        when(userService.saveUser(userTest,true)).thenReturn(Optional.empty());
         when(converters.DTOToUser(userTestDTO)).thenReturn(userTest);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
 
         assertAll(
-                ()->assertEquals(400,userController.insertUser(userTestDTO,userTest).getStatusCodeValue()),
-                ()->assertNull(userController.insertUser(userTestDTO,userTest).getBody())
+                ()->assertEquals(400,userController.insertUser(userTestDTO).getStatusCodeValue()),
+                ()->assertNull(userController.insertUser(userTestDTO).getBody())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -104,11 +101,11 @@ public class UserControllerTests {
 
 
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
-        when(userService.getAllUsers(userTest)).thenReturn(userList);
+        when(userService.getAllUsers()).thenReturn(userList);
         assertAll(
-                ()->assertEquals(200,userController.getAllUsers(userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.getAllUsers(userTest).getBody()),
-                ()->assertTrue(userController.getAllUsers(userTest).getBody().containsAll(userDTOList))
+                ()->assertEquals(200,userController.getAllUsers().getStatusCodeValue()),
+                ()->assertNotNull(userController.getAllUsers().getBody()),
+                ()->assertTrue(userController.getAllUsers().getBody().containsAll(userDTOList))
         );
         verify(converters, times(30)).userToDTO(userTest);
     }
@@ -117,11 +114,11 @@ public class UserControllerTests {
     void testSuccessGetUserById() {
 
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
-        when(userService.getById(10L,userTest)).thenReturn(Optional.of(userTest));
+        when(userService.getById(10L)).thenReturn(Optional.of(userTest));
         assertAll(
-                ()->assertEquals(200,userController.getUserById(10L,userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserById(10L,userTest).getBody()),
-                ()->assertEquals(10L,Objects.requireNonNull(userController.getUserById(10L,userTest)
+                ()->assertEquals(200,userController.getUserById(10L).getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserById(10L).getBody()),
+                ()->assertEquals(10L,Objects.requireNonNull(userController.getUserById(10L)
                         .getBody()).getId().longValue())
         );
         verify(converters, times(3)).userToDTO(userTest);
@@ -131,10 +128,10 @@ public class UserControllerTests {
     void testFailGetUserById() {
 
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
-        when(userService.getById(10L,userTest)).thenReturn(Optional.of(userTest));
+        when(userService.getById(10L)).thenReturn(Optional.of(userTest));
         assertAll(
-                ()->assertEquals(404,userController.getUserById(20L,userTest).getStatusCodeValue()),
-                ()->assertNull(userController.getUserById(20L,userTest).getBody())
+                ()->assertEquals(404,userController.getUserById(20L).getStatusCodeValue()),
+                ()->assertNull(userController.getUserById(20L).getBody())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -144,13 +141,13 @@ public class UserControllerTests {
         List<User> userList=new ArrayList<>();
         userList.add(userTest);
 
-        when(userService.getByFirstname("Susan",userTest)).thenReturn(userList);
+        when(userService.getByFirstname("Susan")).thenReturn(userList);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
         assertAll(
-                ()->assertEquals(200,userController.getUserByFirstname("Susan",userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByFirstname("Susan",userTest).getBody()),
-                ()->assertFalse(Objects.requireNonNull(userController.getUserByFirstname("Susan",userTest).getBody()).isEmpty()),
-                ()->assertEquals("Susan",Objects.requireNonNull(userController.getUserByFirstname("Susan",userTest)
+                ()->assertEquals(200,userController.getUserByFirstname("Susan").getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByFirstname("Susan").getBody()),
+                ()->assertFalse(Objects.requireNonNull(userController.getUserByFirstname("Susan").getBody()).isEmpty()),
+                ()->assertEquals("Susan",Objects.requireNonNull(userController.getUserByFirstname("Susan")
                         .getBody()).get(0).getPersonalData().getFirstname())
         );
         verify(converters, times(4)).userToDTO(userTest);
@@ -158,10 +155,10 @@ public class UserControllerTests {
     @Test
     void testFailGetUserByFirstname() {
         List<User> emptyUserList=new ArrayList<>();
-        when(userService.getByFirstname("Sussan",userTest)).thenReturn(emptyUserList);
+        when(userService.getByFirstname("Sussan")).thenReturn(emptyUserList);
         assertAll(
-                ()->assertNotNull(userController.getUserByFirstname("Sussan",userTest)),
-                ()->assertTrue(Objects.requireNonNull(userController.getUserByFirstname("Sussan",userTest).getBody()).isEmpty())
+                ()->assertNotNull(userController.getUserByFirstname("Sussan")),
+                ()->assertTrue(Objects.requireNonNull(userController.getUserByFirstname("Sussan").getBody()).isEmpty())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -171,13 +168,13 @@ public class UserControllerTests {
         List<User> userList=new ArrayList<>();
         userList.add(userTest);
 
-        when(userService.getByLastname("Barrow",userTest)).thenReturn(userList);
+        when(userService.getByLastname("Barrow")).thenReturn(userList);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
         assertAll(
-                ()->assertEquals(200,userController.getUserByLastname("Barrow",userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByLastname("Barrow",userTest).getBody()),
-                ()->assertFalse(Objects.requireNonNull(userController.getUserByLastname("Barrow",userTest).getBody()).isEmpty()),
-                ()->assertEquals("Barrow",Objects.requireNonNull(userController.getUserByLastname("Barrow",userTest)
+                ()->assertEquals(200,userController.getUserByLastname("Barrow").getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByLastname("Barrow").getBody()),
+                ()->assertFalse(Objects.requireNonNull(userController.getUserByLastname("Barrow").getBody()).isEmpty()),
+                ()->assertEquals("Barrow",Objects.requireNonNull(userController.getUserByLastname("Barrow")
                         .getBody()).get(0).getPersonalData().getLastname())
         );
         verify(converters, times(4)).userToDTO(userTest);
@@ -187,11 +184,11 @@ public class UserControllerTests {
     @Test
     void testFailGetUserByLastname() {
         List<User> emptyUserList=new ArrayList<>();
-        when(userService.getByLastname("Sussan",userTest)).thenReturn(emptyUserList);
+        when(userService.getByLastname("Sussan")).thenReturn(emptyUserList);
         assertAll(
-                ()->assertEquals(200,userController.getUserByLastname("Sussan",userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByLastname("Sussan",userTest)),
-                ()->assertTrue(Objects.requireNonNull(userController.getUserByLastname("Sussan",userTest).getBody()).isEmpty())
+                ()->assertEquals(200,userController.getUserByLastname("Sussan").getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByLastname("Sussan")),
+                ()->assertTrue(Objects.requireNonNull(userController.getUserByLastname("Sussan").getBody()).isEmpty())
         );
         verify(converters, times(0)).userToDTO(userTest);
 
@@ -201,16 +198,16 @@ public class UserControllerTests {
     void testSuccessGetUserByFullname() {
         List<User> userList=new ArrayList<>();
         userList.add(userTest);
-        when(userService.getByFullName("Susan","Barrow",userTest)).thenReturn(userList);
+        when(userService.getByFullName("Susan","Barrow")).thenReturn(userList);
         when(converters.userToDTO(userTest)).thenReturn(userTestDTO);
         assertAll(
-                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow",userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow",userTest)),
+                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow").getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow")),
                 ()->assertEquals("Susan",Objects.requireNonNull(userController
-                        .getUserByFullName("Susan","Barrow",userTest).getBody())
+                        .getUserByFullName("Susan","Barrow").getBody())
                         .get(0).getPersonalData().getFirstname()),
                 ()->assertEquals("Barrow",Objects.requireNonNull(userController
-                        .getUserByFullName("Susan","Barrow",userTest).getBody()).get(0).getPersonalData().getLastname())
+                        .getUserByFullName("Susan","Barrow").getBody()).get(0).getPersonalData().getLastname())
         );
         verify(converters, times(4)).userToDTO(userTest);
     }
@@ -218,11 +215,11 @@ public class UserControllerTests {
     @Test
     void testFailGetUserByFullname() {
         List<User> emptyUserList=new ArrayList<>();
-        when(userService.getByFullName("Susan","Barrow",userTest)).thenReturn(emptyUserList);
+        when(userService.getByFullName("Susan","Barrow")).thenReturn(emptyUserList);
         assertAll(
-                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow",userTest).getStatusCodeValue()),
-                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow",userTest)),
-                ()->assertTrue(Objects.requireNonNull(userController.getUserByFullName("Susan","Barrow",userTest).getBody()).isEmpty())
+                ()->assertEquals(200,userController.getUserByFullName("Susan","Barrow").getStatusCodeValue()),
+                ()->assertNotNull(userController.getUserByFullName("Susan","Barrow")),
+                ()->assertTrue(Objects.requireNonNull(userController.getUserByFullName("Susan","Barrow").getBody()).isEmpty())
         );
         verify(converters, times(0)).userToDTO(userTest);
     }
@@ -230,10 +227,10 @@ public class UserControllerTests {
     @Test
     void testSuccessUpdateUser() {
 
-        when(userService.saveUser(userTest,userTest,false)).thenReturn(Optional.of(userTest));
-        when(userService.getById(10L,userTest)).thenReturn(Optional.of(userTest));
+        when(userService.saveUser(userTest,false)).thenReturn(Optional.of(userTest));
+        when(userService.getById(10L)).thenReturn(Optional.of(userTest));
 
-        assertEquals(202,userController.updateUser(userTestDTO,userTest).getStatusCodeValue());
+        assertEquals(202,userController.updateUser(userTestDTO).getStatusCodeValue());
         verify(converters, times(1)).updateUserWithDTO(userTestDTO,userTest);
 
     }
@@ -241,10 +238,10 @@ public class UserControllerTests {
     @Test
     void testFailUpdateUser() {
 
-        when(userService.saveUser(userTest,userTest,false)).thenReturn(Optional.of(userTest));
-        when(userService.getById(20L,userTest)).thenReturn(Optional.of(userTest));
+        when(userService.saveUser(userTest,false)).thenReturn(Optional.of(userTest));
+        when(userService.getById(20L)).thenReturn(Optional.of(userTest));
 
-        assertEquals(404,userController.updateUser(userTestDTO,userTest).getStatusCodeValue());
+        assertEquals(404,userController.updateUser(userTestDTO).getStatusCodeValue());
         verify(converters, times(0)).updateUserWithDTO(userTestDTO,userTest);
 
     }

--- a/spring-app/src/test/java/com/agh/hr/UserServiceDatabaseIntegrationTests.java
+++ b/spring-app/src/test/java/com/agh/hr/UserServiceDatabaseIntegrationTests.java
@@ -61,16 +61,18 @@ public class UserServiceDatabaseIntegrationTests {
                 .bonuses(Collections.emptyList())
                 .delegations(Collections.emptyList())
                 .applications(Collections.emptyList()).build();
+
         val permissions= Permission.builder().build();
         permissions.addToWrite(10L);
         permissions.setAdd(true);
         userTest.setPermissions(permissions);
+        userTest.getPersonalData().setUser(userTest);
     }
 
     @Test
     void testSaveUser(){
         Optional<User> result=userService.saveUser(userTest,userTest,true);
-        assertEquals(Optional.of(userTest),result);
+        assertTrue(result.isPresent());
     }
 
     @Test
@@ -137,6 +139,7 @@ public class UserServiceDatabaseIntegrationTests {
 
     @Test
     void testDeleteUser(){
+
         assertAll(
                 ()->userService.saveUser(userTest,userTest,true),
                 ()->userService.deleteUser(userTest.getId(),userTest),

--- a/spring-app/src/test/java/com/agh/hr/UserServiceDatabaseIntegrationTests.java
+++ b/spring-app/src/test/java/com/agh/hr/UserServiceDatabaseIntegrationTests.java
@@ -48,7 +48,9 @@ public class UserServiceDatabaseIntegrationTests {
                 .firstname("Susan")
                 .lastname("Barrow")
                 .build();
+
         this.userTest = User.builder()
+                .id(10L)
                 .username("sus")
                 .passwordHash(passwordEncoder.encode("passw0rd"))
                 .enabled(true)
@@ -59,19 +61,22 @@ public class UserServiceDatabaseIntegrationTests {
                 .bonuses(Collections.emptyList())
                 .delegations(Collections.emptyList())
                 .applications(Collections.emptyList()).build();
-
+        val permissions= Permission.builder().build();
+        permissions.addToWrite(10L);
+        permissions.setAdd(true);
+        userTest.setPermissions(permissions);
     }
 
     @Test
     void testSaveUser(){
-        Optional<User> result=userService.saveUser(userTest);
+        Optional<User> result=userService.saveUser(userTest,userTest,true);
         assertEquals(Optional.of(userTest),result);
     }
 
     @Test
     void testSuccessFindByUsername(){
         assertAll(
-                ()->assertTrue(userService.saveUser(userTest).isPresent()),
+                ()->assertTrue(userService.saveUser(userTest,userTest,true).isPresent()),
                 ()->assertTrue(userService.findByUsername("sus").isPresent())
         );
     }
@@ -83,7 +88,7 @@ public class UserServiceDatabaseIntegrationTests {
 
     @Test
     void testGetById(){
-        Optional<User> result=userService.saveUser(userTest);
+        Optional<User> result=userService.saveUser(userTest,userTest,true);
         assertTrue(userService.getById(userTest.getId(),userTest).isPresent());
 
     }
@@ -91,7 +96,7 @@ public class UserServiceDatabaseIntegrationTests {
     @Test
     void testSuccessGetByFirstname(){
         assertAll(
-                ()->assertTrue(userService.saveUser(userTest).isPresent()),
+                ()->assertTrue(userService.saveUser(userTest,userTest,true).isPresent()),
                 ()->assertEquals(1,userService.getByFirstname("Susan",userTest).size())
         );
 
@@ -105,7 +110,7 @@ public class UserServiceDatabaseIntegrationTests {
     @Test
     void testSuccessGetByLastname(){
         assertAll(
-                ()->assertTrue(userService.saveUser(userTest).isPresent()),
+                ()->assertTrue(userService.saveUser(userTest,userTest,true).isPresent()),
                 ()->assertEquals(1,userService.getByLastname("Barrow",userTest).size())
         );
 
@@ -119,7 +124,7 @@ public class UserServiceDatabaseIntegrationTests {
     @Test
     void testSuccessGetByFullName(){
         assertAll(
-                ()->assertTrue(userService.saveUser(userTest).isPresent()),
+                ()->assertTrue(userService.saveUser(userTest,userTest,true).isPresent()),
                 ()->assertEquals(1,userService.getByFullName("Susan","Barrow",userTest).size())
         );
     }
@@ -133,8 +138,8 @@ public class UserServiceDatabaseIntegrationTests {
     @Test
     void testDeleteUser(){
         assertAll(
-                ()->userService.saveUser(userTest),
-                ()->userService.deleteUser(userTest.getId()),
+                ()->userService.saveUser(userTest,userTest,true),
+                ()->userService.deleteUser(userTest.getId(),userTest),
                 ()->assertFalse(userService.getById(userTest.getId(),userTest).isPresent())
         );
     }

--- a/spring-app/src/test/java/com/agh/hr/UserServiceDatabaseIntegrationTests.java
+++ b/spring-app/src/test/java/com/agh/hr/UserServiceDatabaseIntegrationTests.java
@@ -1,4 +1,5 @@
 package com.agh.hr;
+import com.agh.hr.persistence.model.Permission;
 import com.agh.hr.persistence.model.PersonalData;
 import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.repository.UserRepository;
@@ -47,7 +48,6 @@ public class UserServiceDatabaseIntegrationTests {
                 .firstname("Susan")
                 .lastname("Barrow")
                 .build();
-
         this.userTest = User.builder()
                 .username("sus")
                 .passwordHash(passwordEncoder.encode("passw0rd"))
@@ -61,7 +61,6 @@ public class UserServiceDatabaseIntegrationTests {
                 .applications(Collections.emptyList()).build();
 
     }
-    static class UserTest extends User {}
 
     @Test
     void testSaveUser(){
@@ -85,7 +84,7 @@ public class UserServiceDatabaseIntegrationTests {
     @Test
     void testGetById(){
         Optional<User> result=userService.saveUser(userTest);
-        assertTrue(userService.getById(userTest.getId()).isPresent());
+        assertTrue(userService.getById(userTest.getId(),userTest).isPresent());
 
     }
 
@@ -93,41 +92,42 @@ public class UserServiceDatabaseIntegrationTests {
     void testSuccessGetByFirstname(){
         assertAll(
                 ()->assertTrue(userService.saveUser(userTest).isPresent()),
-                ()->assertEquals(1,userService.getByFirstname("Susan").size())
+                ()->assertEquals(1,userService.getByFirstname("Susan",userTest).size())
         );
 
     }
 
     @Test
     void testFailGetByFirstname(){
-        assertEquals(0,userService.getByFirstname("Susan").size());
+        assertEquals(0,userService.getByFirstname("Susan",userTest).size());
     }
 
     @Test
     void testSuccessGetByLastname(){
         assertAll(
                 ()->assertTrue(userService.saveUser(userTest).isPresent()),
-                ()->assertEquals(1,userService.getByLastname("Barrow").size())
+                ()->assertEquals(1,userService.getByLastname("Barrow",userTest).size())
         );
 
     }
 
     @Test
     void testFailGetByLastname(){
-        assertEquals(0,userService.getByLastname("Barrow").size());
+        assertEquals(0,userService.getByLastname("Barrow",userTest).size());
     }
 
     @Test
     void testSuccessGetByFullName(){
         assertAll(
                 ()->assertTrue(userService.saveUser(userTest).isPresent()),
-                ()->assertEquals(1,userService.getByFullName("Susan","Barrow").size())
+                ()->assertEquals(1,userService.getByFullName("Susan","Barrow",userTest).size())
         );
     }
 
     @Test
     void testFailGetByFullName(){
-        assertEquals(0,userService.getByFullName("Susan","Barrow").size());
+        assertEquals(0,userService
+                .getByFullName("Susan","Barrow",userTest).size());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class UserServiceDatabaseIntegrationTests {
         assertAll(
                 ()->userService.saveUser(userTest),
                 ()->userService.deleteUser(userTest.getId()),
-                ()->assertFalse(userService.getById(userTest.getId()).isPresent())
+                ()->assertFalse(userService.getById(userTest.getId(),userTest).isPresent())
         );
     }
 

--- a/spring-app/src/test/java/com/agh/hr/UserServiceTests.java
+++ b/spring-app/src/test/java/com/agh/hr/UserServiceTests.java
@@ -1,11 +1,17 @@
 package com.agh.hr;
 
+import com.agh.hr.controllers.UserController;
+import com.agh.hr.persistence.dto.Converters;
 import com.agh.hr.persistence.model.User;
 import com.agh.hr.persistence.repository.UserRepository;
+import com.agh.hr.persistence.service.RoleService;
 import com.agh.hr.persistence.service.UserService;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,10 +21,9 @@ import static org.mockito.Mockito.when;
 
 public class UserServiceTests {
 
-    private UserService userService;
-
     private UserRepository userRepository;
 
+    private UserService userService;
     private User user;
 
     private String username ;
@@ -26,7 +31,8 @@ public class UserServiceTests {
     @BeforeEach
     public void setup() {
         userRepository = mock(UserRepository.class);
-        userService = new UserService(userRepository);
+        RoleService roleService = mock(RoleService.class);
+        userService = new UserService(userRepository, roleService);
 
         this.username = "foo@gmail.com";
         this.user = User.builder()


### PR DESCRIPTION
Goal of this draft is to present preview of request authentication system before it is introduced to the rest of the project. Currently request authentication is implemented in two layers:
~~- Controller layer, which is responsible for auth that does not require fetching from database - save/update/delete, all scenarios where we could immediatly check for permissions~~
- Database layer, which is responsible for fetching only available data - when user A is requesting list of all users he'll only obtain users who are listed in his read permissions

All controller side authentication was moved to corresponding services. 
All affected tests were also updated.
For the relevant code please refer to ~~450aded3aee8489d145e10b32aa5a946a340ff84 2981ca3aa00c66fe741187b62d10de6c1150a6d7 91e318739aff2e0142f4cfaa143e084c59990227 296a78409d6714486ac8bf831e7e236852033cef~~d842c9a684403ad1bbe11428fce6f98b718d66b5 7c7e3d4c0e753b17fb1f37c993fa8ad68113cb6b
